### PR TITLE
Allow for event filtering on API calls for use in Flutter

### DIFF
--- a/backend/models/event.py
+++ b/backend/models/event.py
@@ -14,6 +14,7 @@ from faker import Faker
 import random
 
 
+
 class Event(BaseModel):
     id: str
     name: str
@@ -148,8 +149,7 @@ async def search_events(
     skip: int = 0,
     limit: int = 100,
     ministry: str = None,
-    min_age: Optional[int] = None,
-    max_age: Optional[int] = None,
+    age: Optional[int] = None,
     gender: Literal["male", "female", "all"] = "all",
     is_free: Optional[bool] = None,
     sort: Literal["asc", "desc"] = "asc",
@@ -164,18 +164,9 @@ async def search_events(
         query["ministry"] = {"$in": [ministry]}
     
     age_filter = {}
-    if min_age is not None:
-        age_filter["$lte"] = min_age
-    if max_age is not None:
-        age_filter["$gte"] = max_age
-    
-    if min_age is not None and max_age is not None:
-        query["min_age"] = {"$lte": max_age}
-        query["max_age"] = {"$gte": min_age}
-    elif min_age is not None:
-         query["max_age"] = {"$gte": min_age}
-    elif max_age is not None:
-         query["min_age"] = {"$lte": max_age}
+    if age is not None:
+        query["min_age"] = {"$lte": age}
+        query["max_age"] = {"$gte": age}
 
     if gender != "all":
         query["gender"] = gender
@@ -209,8 +200,7 @@ async def sort_events(
     skip: int = 0,
     limit: int = 100,
     ministry: str = None,
-    min_age: Optional[int] = None,
-    max_age: Optional[int] = None,
+    age: Optional[int] = None,
     gender: Literal["male", "female", "all"] = "all",
     is_free: Optional[bool] = None,
     sort: Literal["asc", "desc"] = "asc",
@@ -241,13 +231,9 @@ async def sort_events(
     if ministry:
         query["ministry"] = {"$in": [ministry]}
 
-    if min_age is not None and max_age is not None:
-        query["min_age"] = {"$lte": max_age}
-        query["max_age"] = {"$gte": min_age}
-    elif min_age is not None:
-         query["max_age"] = {"$gte": min_age}
-    elif max_age is not None:
-         query["min_age"] = {"$lte": max_age}
+    if age is not None:
+        query["min_age"] = {"$lte": age}
+        query["max_age"] = {"$gte": age}
 
     if gender != "all":
         query["gender"] = gender

--- a/backend/routes/base_routes/event_routes.py
+++ b/backend/routes/base_routes/event_routes.py
@@ -3,6 +3,7 @@ from models.event import sort_events, create_event, get_event_by_id, EventCreate
 from typing import Literal, List
 from bson import ObjectId
 from typing import Optional
+from datetime import date
 
 
 event_router = APIRouter(prefix="/events", tags=["Events"])
@@ -10,8 +11,8 @@ public_event_router = APIRouter(prefix="/events", tags=["Events Public Routes"])
 
 
 @public_event_router.get("/", summary="Get events by filters")
-async def get_events(skip: int = 0, limit: int = 100, ministry: str = None, age: Optional[int] = None, gender: Literal["male", "female", "all"] = "all", is_free: bool = None, sort: Literal["asc", "desc"] = "asc", sort_by: Literal["date", "name", "location", "price", "ministry", "min_age", "max_age", "gender"] = "date"):
-    return await sort_events(skip, limit, ministry, age, gender, is_free, sort, sort_by)
+async def get_events(skip: int = 0, limit: int = 100, ministry: str = None, age: Optional[int] = None, gender: Literal["male", "female", "all"] = "all", is_free: bool = None, sort: Literal["asc", "desc"] = "asc", sort_by: Literal["date", "name", "location", "price", "ministry", "min_age", "max_age", "gender"] = "date", name: Optional[str] = None, max_price: Optional[float] = None, date_after: Optional[date] = None, date_before: Optional[date] = None,):
+    return await sort_events(skip, limit, ministry, age, gender, is_free, sort, sort_by, name=name, max_price=max_price, date_after=date_after, date_before=date_before)
 
 
 @public_event_router.get("/search", summary="Search events")

--- a/backend/routes/base_routes/event_routes.py
+++ b/backend/routes/base_routes/event_routes.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, HTTPException, status
 from models.event import sort_events, create_event, get_event_by_id, EventCreate, update_event, delete_event, search_events, create_mock_events, delete_events, EventOut
 from typing import Literal, List
 from bson import ObjectId
+from typing import Optional
 
 
 event_router = APIRouter(prefix="/events", tags=["Events"])
@@ -9,13 +10,13 @@ public_event_router = APIRouter(prefix="/events", tags=["Events Public Routes"])
 
 
 @public_event_router.get("/", summary="Get events by filters")
-async def get_events(skip: int = 0, limit: int = 100, ministry: str = None, min_age: int = None, max_age: int = None, gender: Literal["male", "female", "all"] = "all", is_free: bool = None, sort: Literal["asc", "desc"] = "asc", sort_by: Literal["date", "name", "location", "price", "ministry", "min_age", "max_age", "gender"] = "date"):
-    return await sort_events(skip, limit, ministry, min_age, max_age, gender, is_free, sort, sort_by)
+async def get_events(skip: int = 0, limit: int = 100, ministry: str = None, age: Optional[int] = None, gender: Literal["male", "female", "all"] = "all", is_free: bool = None, sort: Literal["asc", "desc"] = "asc", sort_by: Literal["date", "name", "location", "price", "ministry", "min_age", "max_age", "gender"] = "date"):
+    return await sort_events(skip, limit, ministry, age, gender, is_free, sort, sort_by)
 
 
 @public_event_router.get("/search", summary="Search events")
-async def search_events_route(query: str, skip: int = 0, limit: int = 100, ministry: str = None, min_age: int = None, max_age: int = None, gender: Literal["male", "female", "all"] = "all", is_free: bool = None, sort: Literal["asc", "desc"] = "asc", sort_by: Literal["date", "name", "location", "price", "ministry", "min_age", "max_age", "gender"] = "date"):
-    return await search_events(query, skip, limit, ministry, min_age, max_age, gender, is_free, sort, sort_by)
+async def search_events_route(query: str, skip: int = 0, limit: int = 100, ministry: str = None, age: Optional[int] = None, gender: Literal["male", "female", "all"] = "all", is_free: bool = None, sort: Literal["asc", "desc"] = "asc", sort_by: Literal["date", "name", "location", "price", "ministry", "min_age", "max_age", "gender"] = "date"):
+    return await search_events(query, skip, limit, ministry, age, gender, is_free, sort, sort_by)
 
 
 @public_event_router.get("/{event_id}", summary="Get event by id")

--- a/frontend/app/lib/pages/eventspage.dart
+++ b/frontend/app/lib/pages/eventspage.dart
@@ -1,5 +1,11 @@
 import 'package:flutter/material.dart';
 
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+const String backendHost = '10.0.2.2:8000';
+
+
 class EventsPage extends StatefulWidget {
   const EventsPage({super.key});
 
@@ -7,40 +13,160 @@ class EventsPage extends StatefulWidget {
   State<EventsPage> createState() => _EventsPageState();
 }
 
+class Event {
+  final String id;
+  final String name;
+  final String description;
+  final String date;
+  final String location;
+  final double price;
+  final List<String> ministry;
+  final int minAge;
+  final int maxAge;
+  final String gender;
+
+  Event({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.date,
+    required this.location,
+    required this.price,
+    required this.ministry,
+    required this.minAge,
+    required this.maxAge,
+    required this.gender,
+  });
+
+  factory Event.fromJson(Map<String, dynamic> json) {
+    return Event(
+      id: json['id'],
+      name: json['name'],
+      description: json['description'],
+      date: json['date'],
+      location: json['location'],
+      price: (json['price'] as num).toDouble(),
+      ministry: List<String>.from(json['ministry']),
+      minAge: json['min_age'],
+      maxAge: json['max_age'],
+      gender: json['gender'],
+    );
+  }
+}
+
+
 class _EventsPageState extends State<EventsPage> {
+  List<Event> _events = [];
+  bool _isLoading = true;
+
+  // Declare variables for dynamic filter values
+  int? _minAge;
+  int? _maxAge;
+  String? _ministry;
+  bool? _isFree;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadEvents();
+  }
+
+  Future<void> _loadEvents() async {
+    setState(() {
+      _isLoading = true;
+    });
+
+    final uri = Uri.http(
+      backendHost, // just host + port
+      '/api/v1/events', // full path to your FastAPI endpoint
+      {
+        if (_minAge != null) 'min_age': _minAge.toString(),
+        if (_maxAge != null) 'max_age': _maxAge.toString(),
+        if (_ministry != null) 'ministry': _ministry!,
+        if (_isFree != null) 'is_free': _isFree.toString(),
+      },
+    );
+
+    try {
+      final response = await http.get(uri);
+      if (response.statusCode == 200) {
+        final List<dynamic> jsonData = jsonDecode(response.body);
+        setState(() {
+          _events = jsonData.map((json) => Event.fromJson(json)).toList();
+          _isLoading = false;
+        });
+      } else {
+        print("Failed to load events: ${response.statusCode}");
+        setState(() => _isLoading = false);
+      }
+    } catch (e) {
+      print("Error loading events: $e");
+      setState(() => _isLoading = false);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-          return Scaffold(
-            appBar: AppBar(
-            backgroundColor: const Color.fromARGB(159, 144, 79, 230),
-             iconTheme: const IconThemeData(
-                    color: Colors.white), // back arrow color
-              title: Padding(
-                 padding: const EdgeInsets.only(left: 100),
-                 child: Text(
-                   "Events",
-                  style:
-                  const TextStyle(color: Colors.white), // title color
-                ),
-              ),
-              leading: IconButton(
-              icon: const Icon(Icons.arrow_back),
-                onPressed: () {
-                  Navigator.pop(context);
-                 },
-              ),
-            ),
-            backgroundColor: const Color.fromARGB(246, 244, 236, 255), //old: const Color.fromARGB(156, 102, 133, 161),
-             body: SafeArea(
-              minimum: const EdgeInsets.symmetric(horizontal: 10),
-              child: SingleChildScrollView(
-                child: Column(
-                 children: [
-                      Text( "Hello")
-                  ],
-                 ),
-               ),
-            ),
-          );
-         }
-      }
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: const Color.fromARGB(159, 144, 79, 230),
+        iconTheme: const IconThemeData(color: Colors.white),
+        title: const Padding(
+          padding: EdgeInsets.only(left: 100),
+          child: Text(
+            "Events",
+            style: TextStyle(color: Colors.white),
+          ),
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () {
+            Navigator.pop(context);
+          },
+        ),
+      ),
+      backgroundColor: const Color.fromARGB(246, 244, 236, 255),
+      body: SafeArea(
+        minimum: const EdgeInsets.symmetric(horizontal: 10),
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              _isLoading
+                  ? const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 50),
+                      child: Center(
+                        child: CircularProgressIndicator(),
+                      ),
+                    )
+                  : _events.isEmpty
+                      ? const Padding(
+                          padding: EdgeInsets.symmetric(vertical: 50),
+                          child: Text("No events found."),
+                        )
+                      : ListView.builder(
+                          physics: const NeverScrollableScrollPhysics(),
+                          shrinkWrap: true,
+                          itemCount: _events.length,
+                          itemBuilder: (context, index) {
+                            final event = _events[index];
+                            return Card(
+                              margin: const EdgeInsets.symmetric(vertical: 8),
+                              child: ListTile(
+                                title: Text(event.name),
+                                subtitle: Text(event.description),
+                                trailing: Text(
+                                  event.price == 0
+                                      ? "Free"
+                                      : "\$${event.price.toStringAsFixed(2)}",
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Allows for the filtering of displayed events. 

Events as viewable in Flutter:
![qemu-system-x86_64_1KhaOB9mEO](https://github.com/user-attachments/assets/aec063a2-4c78-429b-8c66-2448447c8fe5)

At the moment, the UI elements for filtering do not exist yet. However, we can observe that filtering does work in API calls. 

Sample events in MongoDB:
![MongoDBCompass_W5sBgul9tq](https://github.com/user-attachments/assets/b83920fd-83a4-44db-b6cf-9367bbc8342c)

Sample events in terminal when accessed through the API, first with no filters and second with age mentioned:
![Code_Ohcra4ULep](https://github.com/user-attachments/assets/d955e4b5-4d65-4150-ac98-50ae59ffbdd7)

The second call does not display the event for Seniors because the test age, 25, is outside of the min and max age range of it. 
