### PR TITLE
Feature/event reminder notification

### DIFF
--- a/frontend/app/lib/pages/eventspage.dart
+++ b/frontend/app/lib/pages/eventspage.dart
@@ -6,6 +6,7 @@ import '../models/event_registration_summary.dart';
 import '../services/event_registration_service.dart';
 import '../widgets/enhanced_event_card.dart';
 import 'event_showcase.dart';
+import 'package:add_2_calendar/add_2_calendar.dart' as a2c;
 
 class EventsPage extends StatefulWidget {
   const EventsPage({super.key});
@@ -362,13 +363,28 @@ class _EventsPageState extends State<EventsPage> {
     }
   }
 
-  void _onAddToCalendar(Event event) {
+  void _onAddToCalendar(Event event) async {
+    final DateTime start = event.date.toLocal();
+    final DateTime end = start.add(const Duration(hours: 1));
+
+    final calEvent = a2c.Event(
+      title: event.name,
+      description: event.description,
+      location: event.location,
+      startDate: start,
+      endDate: end,
+      allDay: false,
+      iosParams: const a2c.IOSParams(reminder: Duration(minutes: 60)),
+      androidParams: const a2c.AndroidParams(),
+    );
+
+    final ok = await a2c.Add2Calendar.addEvent2Cal(calEvent);
+
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Add to Calendar tapped')),
+      SnackBar(content: Text(ok ? 'Opening calendar…' : 'Couldn\'t open calendar')),
     );
   }
-
 
   @override
   Widget build(BuildContext context) {

--- a/frontend/app/lib/pages/eventspage.dart
+++ b/frontend/app/lib/pages/eventspage.dart
@@ -362,6 +362,14 @@ class _EventsPageState extends State<EventsPage> {
     }
   }
 
+  void _onAddToCalendar(Event event) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Add to Calendar tapped')),
+    );
+  }
+
+
   @override
   Widget build(BuildContext context) {
     const Color ssbcGray = Color.fromARGB(255, 142, 163, 168);
@@ -402,10 +410,23 @@ class _EventsPageState extends State<EventsPage> {
                     itemCount: _events.length,
                     itemBuilder: (context, index) {
                       final event = _events[index];
-                      return EnhancedEventCard(
-                        event: event,
-                        onViewPressed: () => _navigateToShowcase(event),
-                        registrationSummary: _registrationSummaries[event.id],
+                      return Stack(
+                        children: [
+                          EnhancedEventCard(
+                            event: event,
+                            onViewPressed: () => _navigateToShowcase(event),
+                            registrationSummary: _registrationSummaries[event.id],
+                          ),
+                          Positioned(
+                            bottom: 12,
+                            right: 12,
+                            child: IconButton(
+                              tooltip: 'Add to Calendar',
+                              icon: const Icon(Icons.calendar_month_outlined),
+                              onPressed: () => _onAddToCalendar(event),
+                            ),
+                          ),
+                        ],
                       );
                     },
                   ),

--- a/frontend/app/pubspec.yaml
+++ b/frontend/app/pubspec.yaml
@@ -64,6 +64,7 @@ dependencies:
   webview_flutter_wkwebview: ^3.13.0
   share_plus: ^10.0.2
   open_filex: ^4.5.0
+  android_intent_plus: ^5.2.0
   
 dev_dependencies:
   flutter_test:

--- a/frontend/app/pubspec.yaml
+++ b/frontend/app/pubspec.yaml
@@ -62,7 +62,8 @@ dependencies:
   logger: ^2.0.2+1
   webview_flutter_android: ^4.10.2
   webview_flutter_wkwebview: ^3.13.0
-  add_2_calendar: ^2.2.5
+  share_plus: ^10.0.2
+  open_filex: ^4.5.0
   
 dev_dependencies:
   flutter_test:

--- a/frontend/app/pubspec.yaml
+++ b/frontend/app/pubspec.yaml
@@ -62,6 +62,7 @@ dependencies:
   logger: ^2.0.2+1
   webview_flutter_android: ^4.10.2
   webview_flutter_wkwebview: ^3.13.0
+  add_2_calendar: ^2.2.5
   
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Add an "Add To Calendar" button to event tiles, based on https://github.com/AlphaHasher/ChurchLink/pull/180. Clicking the button will default to Google Calendar if the user has that installed. Otherwise, the event is formatted as .ics and the user is asked which app they want to open it with. 

At the moment, events end times are defaulted to one hour after. Our backend doesn't support event end times and Google Calendar requires one for Event entries. If this changes in the future, we can add support for it. 

Testing has only been done on Android, but on iOS it should be passed to the OS as an .ics file, which it should handle. 

https://github.com/user-attachments/assets/1d841788-1f48-45eb-acc0-c0c886712298


