### PR TITLE
NOTE: THIS IS A PR TO MERGE TO DANIEL'S BRANCH, NOT MAIN

### DIFF
--- a/frontend/web/churchlink/src/features/admin/components/AdminDashboardSideBar.tsx
+++ b/frontend/web/churchlink/src/features/admin/components/AdminDashboardSideBar.tsx
@@ -15,6 +15,7 @@ import {
   Newspaper,
   Lectern,
   Wallet,
+  ArrowLeft,
 } from "lucide-react";
 import {
   Sidebar,
@@ -61,7 +62,8 @@ const AdminDashboardSideBar = () => {
   );
 
   const items: Item[] = [
-    { title: "Home", url: "/", icon: Home },
+    { title: "Go Back to Main Site", url: "/", icon: ArrowLeft },
+    { title: "Admin Panel Home", url: "/admin/", icon: Home },
     {
       title: "Users", url: "/admin/users", icon: User, children: [
         { title: "Management", url: "/admin/users/manage-users" },

--- a/frontend/web/churchlink/src/shared/components/NavBar.tsx
+++ b/frontend/web/churchlink/src/shared/components/NavBar.tsx
@@ -43,6 +43,7 @@ interface NavBarProps {
 export default function NavBar({ headerData }: NavBarProps = {}) {
     const [headerItems, setHeaderItems] = useState<HeaderItem[]>(headerData || []);
     const [loading, setLoading] = useState(!headerData);
+    const [isMod, setIsMod] = useState(false);
     const [activeDropdown, setActiveDropdown] = useState<string | null>(null);
     const { user } = useAuth();
     const navigate = useNavigate();
@@ -94,6 +95,20 @@ export default function NavBar({ headerData }: NavBarProps = {}) {
         };
 
         fetchHeaderItems();
+
+        // Check if user is mod
+        const checkIfMod = async () => {
+            try {
+                const res = await api.get("/v1/users/check-mod");
+                setIsMod(res.data['success']);
+            } catch (error) {
+                console.error("Error checking if user is mod:", error);
+                setIsMod(false);
+            }
+        }
+
+        checkIfMod();
+
     }, [headerData]);
 
     return (
@@ -165,7 +180,7 @@ export default function NavBar({ headerData }: NavBarProps = {}) {
                     {user ? (
                         // Authenticated user - show profile dropdown
                         <div className="hidden lg:flex items-center justify-center h-full w-9">
-                            <ProfileDropDown className="hover:bg-white/10 hover:text-gray-300 transition-colors duration-200 p-0! rounded-full!" />
+                            <ProfileDropDown className="hover:bg-white/10 hover:text-gray-300 transition-colors duration-200 p-0! rounded-full!" isMod={isMod} />
                         </div>
                     ) : (
                         // Unauthenticated user - show login button

--- a/frontend/web/churchlink/src/shared/components/ProfileDropDown.tsx
+++ b/frontend/web/churchlink/src/shared/components/ProfileDropDown.tsx
@@ -11,13 +11,17 @@ import { useAuth } from "@/features/auth/hooks/auth-context";
 import { Link } from "react-router-dom";
 import { auth, signOut } from "@/lib/firebase";
 import AvatarImg from "./AvatarImg";
+import { Shield } from "lucide-react";
 
 interface ProfileDropDownProps {
   className?: string;
+  isMod?: boolean;
 }
 
-function ProfileDropDown({ className }: ProfileDropDownProps) {
+function ProfileDropDown({ className, isMod }: ProfileDropDownProps) {
   const { user } = useAuth();
+
+  const displayAdminDash: boolean = isMod ?? false;
 
   return (
     <DropdownMenu>
@@ -59,6 +63,20 @@ function ProfileDropDown({ className }: ProfileDropDownProps) {
             <span>Profile</span>
           </Link>
         </DropdownMenuItem>
+        {displayAdminDash ? (
+          <DropdownMenuItem asChild>
+            <Link
+              to="/admin"
+              className="flex items-center gap-2 px-3 py-2 text-sm text-popover-foreground hover:bg-accent hover:text-accent-foreground cursor-pointer rounded-lg mx-1 my-0.5 transition-colors duration-200"
+              aria-label="Admin Panel"
+              title="Admin Panel"
+            >
+              <Shield className="h-4 w-4" />
+              <span>Admin Panel</span>
+            </Link>
+          </DropdownMenuItem>
+        ) : null}
+
         <DropdownMenuItem
           onClick={() => {
             signOut(auth);


### PR DESCRIPTION
Made some changes to admin panel navigation to make the user's life a bit easier.

<img width="399" height="290" alt="image" src="https://github.com/user-attachments/assets/8ae3aff4-b451-45df-9410-7bd68d5b8b6c" />

If the user is mod, and only if the user is mod, a "go to admin panel" button will appear in profile. If user has no perms, stays the same.

<img width="365" height="1056" alt="image" src="https://github.com/user-attachments/assets/ee88661a-1f29-4898-8b27-735521d42c5b" />

Instead of side panel having "Home" to leave the admin dash, it now has an explicit option to "Leave to main site" to exit the panel, and an "Admin Panel Home" to go to the /admin landing page