### PR TITLE
Recommended Aesthetic Changes

### DIFF
--- a/frontend/web/churchlink/src/features/admin/components/AdminDashboardSideBar.tsx
+++ b/frontend/web/churchlink/src/features/admin/components/AdminDashboardSideBar.tsx
@@ -14,6 +14,7 @@ import {
   ClipboardList,
   Newspaper,
   Lectern,
+  Church,
   Wallet,
 } from "lucide-react";
 import {
@@ -70,7 +71,7 @@ const AdminDashboardSideBar = () => {
     },
 
     { title: "Permissions", url: "/admin/permissions", icon: Shield },
-    { title: "Ministries", url: "/admin/ministries", icon: Lectern },
+    { title: "Ministries", url: "/admin/ministries", icon: Church },
     { title: "Web Builder", icon: FileText, children: webBuilderChildren },
     { title: "Media Library", url: "/admin/media-library", icon: Image },
     { title: "Mobile UI", url: "/admin/mobile-ui-tab", icon: Smartphone },

--- a/frontend/web/churchlink/src/features/admin/pages/AdminDashboard.tsx
+++ b/frontend/web/churchlink/src/features/admin/pages/AdminDashboard.tsx
@@ -29,6 +29,7 @@ import {
   Shield,
   CalendarFold,
   Lectern,
+  Church,
 } from "lucide-react";
 
 type Tile = {
@@ -52,6 +53,13 @@ const tiles: Tile[] = [
       "View all the various permission roles, create, edit, and delete permission roles. Quickly view all the users that have a particular permission role.",
     icon: Shield,
     to: "/admin/permissions",
+  },
+  {
+    title: "Ministries",
+    description:
+      "Create and manage ministry categorizations to apply to events, forms, sermons, and more.",
+    icon: Church,
+    to: "/admin/ministries",
   },
   {
     title: "Web Builder",


### PR DESCRIPTION
Minor Changes recommended for UI

Change 1: 
<img width="385" height="1039" alt="image" src="https://github.com/user-attachments/assets/8e05d4f9-b131-4ace-a0fb-d4fc16f3e78e" />

Ministry icon as church instead of lectern for no other reason than I think not re-using icons looks good

Change 2:

<img width="1833" height="956" alt="image" src="https://github.com/user-attachments/assets/58499e5d-f24e-4106-a275-7ef51676dbd0" />

Adds ministries tile to admin dash home