### PR TITLE
Hotfix/Image Previewer

### DIFF
--- a/frontend/web/churchlink/src/features/admin/components/Media/ImagePreviewDialog.tsx
+++ b/frontend/web/churchlink/src/features/admin/components/Media/ImagePreviewDialog.tsx
@@ -3,6 +3,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogD
 import { Button } from '@/shared/components/ui/button';
 import { Input } from '@/shared/components/ui/input';
 import { Textarea } from '@/shared/components/ui/textarea';
+import { Trash, Download, Save } from 'lucide-react';
 import type { ImageResponse } from '@/shared/types/ImageData';
 
 type Props = {
@@ -77,25 +78,30 @@ export const ImagePreviewDialog: React.FC<Props> = ({ open, image, canManage = f
                         <a
                             href={downloadHref}
                             download={`${(image.name || image.id)}.${image.extension || 'bin'}`}
-                            className="inline-flex items-center justify-center rounded-md border bg-background px-3 py-2 text-sm"
+                            className="inline-flex items-center justify-center rounded-md border bg-background px-3 py-2 text-sm hover:bg-accent transition-colors"
                         >
+                            <Download className="mr-2 h-4 w-4" />
                             Download
                         </a>
-                        <Button
-                            variant="destructive"
-                            onClick={() => {
-                                if (!canManage) { window.alert('You do not have permission to delete images.'); return; }
-                                onRequestDelete?.();
-                            }}
-                        >
-                            Delete
-                        </Button>
+                        {onRequestDelete && (
+                            <Button
+                                variant="destructive"
+                                onClick={() => {
+                                    if (!canManage) { window.alert('You do not have permission to delete images.'); return; }
+                                    onRequestDelete();
+                                }}
+                            >
+                                <Trash className="mr-2 h-4 w-4" />
+                                Delete
+                            </Button>
+                        )}
                         <Button
                             onClick={() => {
                                 if (!canManage) { window.alert('You do not have permission to save image updates.'); return; }
                                 onSave(image.id, { new_name: name.trim() || image.name, new_description: (desc ?? '').trim() || null });
                             }}
                         >
+                            <Save className="mr-2 h-4 w-4" />
                             Save
                         </Button>
                     </DialogFooter>

--- a/frontend/web/churchlink/src/features/admin/pages/MediaLibrary.tsx
+++ b/frontend/web/churchlink/src/features/admin/pages/MediaLibrary.tsx
@@ -601,12 +601,6 @@ const MediaLibrary: React.FC<{
           image={selectedImage}
           canManage={canManage}
           onOpenChange={() => setSelectedImage(null)}
-          onRequestDelete={() => {
-            if (!canManage) { window.alert('You do not have permission to delete images.'); return; }
-            if (!selectedImage) return;
-            setDeletingImage(selectedImage);
-            setDeleteConfirmOpen(true);
-          }}
           onSave={async (id, data) => {
             if (!requireManage('save image updates')) return;
             try {
@@ -619,6 +613,13 @@ const MediaLibrary: React.FC<{
             } catch {
               setError('Failed to update image');
             }
+          }}
+          onRequestDelete={() => {
+            if (!canManage) { window.alert('You do not have permission to delete images.'); return; }
+            if (!selectedImage) return;
+            setDeletingImage(selectedImage);
+            setDeleteConfirmOpen(true);
+            setSelectedImage(null);
           }}
         />
       )}


### PR DESCRIPTION
This pull request adds support for deleting images in the media library, including UI changes and permission checks to ensure only authorized users can perform deletions. The main changes introduce a "Delete" button in the image preview dialog, wire up its behavior to the parent media library component, and ensure proper state handling after deletion.

**Image Deletion Feature:**

* Added an optional `onRequestDelete` prop to the `ImagePreviewDialog` component and passed it from the `MediaLibrary` parent, enabling the dialog to request image deletion. [[1]](diffhunk://#diff-873d71bcf9bbda30bd243037f0b0f2c1766542529b61c4a7da2a7d6268668fa9R14-R17) [[2]](diffhunk://#diff-f1630ea98876cb2ba605815c2836f939ebd4b75cc1ca0a5a2d06df2af395381eR604-R609)
* Introduced a "Delete" button to the `ImagePreviewDialog` UI, which checks user permissions before invoking the deletion request.

**State and Permission Handling:**

* In the `MediaLibrary` component, handled the image deletion flow by setting state variables for deleting image and confirmation dialog, and ensured permission checks before proceeding.
* After a successful image deletion, updated state to close dialogs and clear the selected image, ensuring the UI reflects the change.