### PR TITLE
Fix: ensure templates cache is initialized to an empty array on load …

### DIFF
--- a/frontend/web/churchlink/src/features/admin/components/BiblePlanManager/PlanSidebar.tsx
+++ b/frontend/web/churchlink/src/features/admin/components/BiblePlanManager/PlanSidebar.tsx
@@ -90,8 +90,7 @@ const PlanSidebar = ({ plan, setPlan, selectedDay, onCreatePassageForDay, initia
       templatesInFlight = api.get('/v1/bible-plans/templates')
         .then(r => r.data as ReadingPlanWithId[])
         .then(data => {
-          templatesCache = data || [];
-          return templatesCache;
+          return data || [];
         })
         .finally(() => {
           templatesInFlight = null;


### PR DESCRIPTION
This pull request makes a minor improvement to the handling of API data in the `PlanSidebar` component. The change ensures that if the API response is `null` or `undefined`, the code will safely default to using an empty array, which helps prevent possible runtime errors when working with the templates data.