### PR TITLE
auto-enable visibility in forms and make a component for visibility

### DIFF
--- a/frontend/web/churchlink/src/features/admin/pages/ManageBiblePlans.tsx
+++ b/frontend/web/churchlink/src/features/admin/pages/ManageBiblePlans.tsx
@@ -18,31 +18,18 @@ ModuleRegistry.registerModules([
 ]);
 
 import BiblePlansTabs from '@/features/admin/components/BiblePlanManager/BiblePlansTabs';
+import { VisibilityToggleCellRenderer } from '@/shared/components/VisibilityToggle';
 import api from '@/api/api';
 import { Input } from '@/shared/components/ui/input';
 import { Button } from '@/shared/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from '@/shared/components/ui/dropdown-menu';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/shared/components/ui/alert-dialog';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/shared/components/ui/Dialog';
-import { Switch } from '@/shared/components/ui/switch';
 import { MoreHorizontal, Pencil, Copy, Download, Trash, RefreshCcw } from 'lucide-react';
 import { Skeleton } from '@/shared/components/ui/skeleton';
 
-// Cell renderer for visible column (switch)
-const VisibleCellRenderer = (props: ICellRendererParams) => {
-  const { data, context } = props;
-  if (!data) return null;
-
-  const { handleToggleVisible } = context;
-
-  return (
-    <Switch
-      checked={!!data.visible}
-      onCheckedChange={(c) => handleToggleVisible(data.id, !!c)}
-      aria-label="Toggle visibility"
-    />
-  );
-};
+// Cell renderer for visible column
+const VisibleCellRenderer = VisibilityToggleCellRenderer;
 
 // Cell renderer for actions column
 const ActionsCellRenderer = (props: ICellRendererParams) => {
@@ -218,7 +205,9 @@ const ManageBiblePlans = () => {
       field: 'visible',
       headerName: 'Visible',
       flex: 1,
+      minWidth: 120,
       cellRenderer: VisibleCellRenderer,
+      cellStyle: { display: 'grid', placeItems: 'center', padding: 0 },
     },
     {
       headerName: 'Actions',
@@ -232,6 +221,9 @@ const ManageBiblePlans = () => {
   const gridContext = {
     handleEdit,
     handleToggleVisible,
+    onToggleVisibility: async (id: string, newVisibility: boolean) => {
+      await handleToggleVisible(id, newVisibility);
+    },
     handleDuplicate,
     handleExport,
     setRenameTarget,

--- a/frontend/web/churchlink/src/features/admin/pages/ManageForms.tsx
+++ b/frontend/web/churchlink/src/features/admin/pages/ManageForms.tsx
@@ -20,6 +20,7 @@ ModuleRegistry.registerModules([
 
 import FormsTabs from '@/features/admin/components/Forms/FormsTabs';
 import { EventMinistryDropdown } from '@/features/admin/components/Events/EventMinistryDropdown';
+import { VisibilityToggleCellRenderer } from '@/shared/components/VisibilityToggle';
 import api from '@/api/api';
 import { Input } from '@/shared/components/ui/input';
 import { Button } from '@/shared/components/ui/button';
@@ -27,7 +28,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from '@/shared/components/ui/dropdown-menu';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/shared/components/ui/alert-dialog';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/shared/components/ui/Dialog';
-import { Switch } from '@/shared/components/ui/switch';
 import { MoreHorizontal, Pencil, FileEdit, Copy, Download, Trash, RefreshCcw, AlertTriangle } from 'lucide-react';
 import { fetchResponsesAndDownloadCsv } from '@/shared/utils/csvExport';
 import { Skeleton } from '@/shared/components/ui/skeleton';
@@ -114,21 +114,7 @@ const LinksCellRenderer = (props: ICellRendererParams) => {
   );
 };
 
-// Cell renderer for visible column (switch)
-const VisibleCellRenderer = (props: ICellRendererParams) => {
-  const { data, context } = props;
-  if (!data) return null;
-
-  const { handleToggleVisible } = context;
-
-  return (
-    <Switch
-      checked={!!data.visible}
-      onCheckedChange={(c) => handleToggleVisible(data.id, !!c)}
-      aria-label="Toggle visibility"
-    />
-  );
-};
+const VisibleCellRenderer = VisibilityToggleCellRenderer;
 
 // Cell renderer for actions column
 const ActionsCellRenderer = (props: ICellRendererParams) => {
@@ -261,8 +247,9 @@ const ManageForms = () => {
       headerName: 'Visible',
       field: 'visible',
       flex: 1,
-      minWidth: 80,
+      minWidth: 120,
       cellRenderer: VisibleCellRenderer,
+      cellStyle: { display: 'grid', placeItems: 'center', padding: 0 },
     },
     {
       headerName: 'Expired',
@@ -703,6 +690,9 @@ const ManageForms = () => {
                 setRenameTarget,
                 setConfirmDeleteIds,
                 handleToggleVisible,
+                onToggleVisibility: async (id: string, newVisibility: boolean) => {
+                  await handleToggleVisible(id, newVisibility);
+                },
                 slugify,
                 setAssignmentTarget,
                 openMinistryAssignment,

--- a/frontend/web/churchlink/src/shared/components/VisibilityToggle.tsx
+++ b/frontend/web/churchlink/src/shared/components/VisibilityToggle.tsx
@@ -1,0 +1,136 @@
+import { useState } from "react";
+import MultiStateBadge from "@/shared/components/MultiStageBadge";
+
+interface VisibilityToggleProps {
+  /** The current visibility state */
+  visible: boolean;
+  /** Callback function to update visibility. Should return a Promise that resolves when the API call completes. */
+  onToggle: (newVisibility: boolean) => Promise<void>;
+  /** Optional: Custom labels for visible/hidden states */
+  labels?: {
+    visible?: string;
+    hidden?: string;
+  };
+  /** Optional: Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * A reusable visibility toggle component with animated state transitions.
+ * 
+ * Features:
+ * - Animated transitions between states (visible/hidden/processing/success/error)
+ * - Automatic state management for loading and success states
+ * - Error handling with automatic recovery
+ * - Accessible and keyboard-friendly
+ * 
+ * @example
+ * ```tsx
+ * <VisibilityToggle
+ *   visible={item.visible}
+ *   onToggle={async (newVisibility) => {
+ *     await api.put(`/items/${item.id}`, { visible: newVisibility });
+ *   }}
+ * />
+ * ```
+ */
+export function VisibilityToggle({
+  visible,
+  onToggle,
+  labels = { visible: "Visible", hidden: "Hidden" },
+  className = "",
+}: VisibilityToggleProps) {
+  const [badgeState, setBadgeState] = useState<"custom" | "processing" | "success" | "error">("custom");
+
+  const handleToggle = async () => {
+    // Prevent clicking while processing
+    if (badgeState !== "custom") return;
+
+    const newVisibility = !visible;
+    setBadgeState("processing");
+
+    try {
+      await onToggle(newVisibility);
+      setBadgeState("success");
+      
+      // Auto-revert to custom state after success animation
+      setTimeout(() => {
+        setBadgeState("custom");
+      }, 900);
+    } catch (error) {
+      console.error("Error toggling visibility:", error);
+      setBadgeState("error");
+      
+      // Auto-revert to custom state after error animation
+      setTimeout(() => {
+        setBadgeState("custom");
+      }, 1200);
+    }
+  };
+
+  return (
+    <div className={`flex items-center justify-center h-full w-full overflow-visible ${className}`}>
+      <MultiStateBadge
+        state={badgeState}
+        onClick={handleToggle}
+        customComponent={
+          <span
+            className={`inline-block px-2 py-1 text-xs rounded-full font-medium cursor-pointer ${
+              visible
+                ? "bg-green-500/20 text-green-400 dark:bg-green-400 dark:text-green-900"
+                : "bg-red-500/20 text-red-400 dark:bg-red-400 dark:text-red-900"
+            }`}
+          >
+            {visible ? labels.visible : labels.hidden}
+          </span>
+        }
+      />
+    </div>
+  );
+}
+
+/**
+ * Cell renderer component for use with AG Grid tables.
+ * 
+ * @example
+ * ```tsx
+ * // In your column definitions:
+ * {
+ *   headerName: "Visibility",
+ *   field: "visible",
+ *   cellRenderer: VisibilityToggleCellRenderer,
+ *   cellStyle: { display: 'grid', placeItems: 'center', padding: 0 },
+ * }
+ * 
+ * // In your AG Grid context:
+ * context={{
+ *   onToggleVisibility: async (id: string, newVisibility: boolean) => {
+ *     await api.put(`/items/${id}`, { visible: newVisibility });
+ *     // Update local state
+ *     setItems(prev => prev.map(item => 
+ *       item.id === id ? { ...item, visible: newVisibility } : item
+ *     ));
+ *   }
+ * }}
+ * ```
+ */
+export function VisibilityToggleCellRenderer(props: any) {
+  const { data, value, context } = props;
+  if (!data) return null;
+
+  const { onToggleVisibility } = context || {};
+  
+  if (!onToggleVisibility) {
+    console.warn("VisibilityToggleCellRenderer: onToggleVisibility not provided in context");
+    return null;
+  }
+
+  return (
+    <VisibilityToggle
+      visible={value}
+      onToggle={async (newVisibility) => {
+        await onToggleVisibility(data.id || data._id, newVisibility);
+      }}
+    />
+  );
+}


### PR DESCRIPTION
This pull request updates the form management workflow to streamline the process of enabling form visibility when creating a slug, especially for forms that already have ministries assigned. The main changes enhance the user experience by automatically making forms visible after a slug is created, if possible, and guiding users to assign ministries when necessary.

**Improvements to form visibility and slug creation workflow:**

* Added an `autoEnableVisibility` flag to the `slugDialog` state and the `openCreateSlug` function, allowing the system to determine if visibility should be auto-enabled when creating a slug. [[1]](diffhunk://#diff-4c91b0ab07440a821dae3c0ed0b5b71ea22dd3f6af193816fd0cc1b5e99fda64L192-R192) [[2]](diffhunk://#diff-4c91b0ab07440a821dae3c0ed0b5b71ea22dd3f6af193816fd0cc1b5e99fda64L460-R496)
* Updated the logic when attempting to make a form visible without a slug: now calls `openCreateSlug` with `autoEnableVisibility` set to `true`, so the form can be made visible immediately after slug creation if eligible.
* Enhanced the `saveSlug` function to:
  - Automatically enable form visibility if `autoEnableVisibility` is true and the form has assigned ministries.
  - Prompt users to assign ministries if they attempt to enable visibility but none are assigned, providing clear status feedback and opening the assignment dialog.