### PR TITLE
Fix/app theme

### DIFF
--- a/frontend/app/lib/pages/giving.dart
+++ b/frontend/app/lib/pages/giving.dart
@@ -444,12 +444,7 @@ class _GivingState extends State<Giving> {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      theme: Theme.of(context),
-      darkTheme: Theme.of(context),
-      title: 'Church Giving',
-      debugShowCheckedModeBanner: false,
-      home: Scaffold(
+    return Scaffold(
       appBar: AppBar(
         title: const Text(
           'Church Giving',
@@ -728,7 +723,6 @@ class _GivingState extends State<Giving> {
             ),
           ),
         ),
-      ),
     );
   }
 


### PR DESCRIPTION
Small theme fix for the Giving Page. Issue was outlined in #307. Branch name mentions #319 but this was seemingly already fixed and closed. 

<img width="369" height="820" alt="qemu-system-x86_64_PFxOfMzbwP" src="https://github.com/user-attachments/assets/96b45d7e-25f1-4fc9-8be3-bb397464f674" /> <img width="369" height="820" alt="qemu-system-x86_64_ZbYFKy6vDS" src="https://github.com/user-attachments/assets/14499f48-57e1-47d4-aeeb-0b8958d5b4b9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * UI now consistently uses the app theme for headers, cards, text, icons, snackbars, input fields, borders, hints and error states for improved light/dark mode consistency.
  * Page layout now relies on the app scaffold so theme settings apply correctly.
  * Visual PayPal button branding remains blue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->